### PR TITLE
New "list" SubCommand and other Fixes

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,12 +2,13 @@ name: MineReset
 main: minereset\MineReset
 version: 2.3
 author: Falk
-api: [1.0.0, 2.0.0]
+api: [1.0.0, 2.0.0, 3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
 load: POSTWORLD
 commands:
  mine:
-  description: MineReset command
-  usage: /mine < create <name> / set <name> <contents> / reset <name> / destroy <name> / reset-all >
+  description: "MineReset command"
+  usage: "/mine <create|set|list|reset|reset-all|destroy> <name> [parameters]"
+  permission: minereset.command
 permissions:
  minereset:
   default: op

--- a/src/minereset/MineReset.php
+++ b/src/minereset/MineReset.php
@@ -162,9 +162,10 @@ class MineReset extends PluginBase implements Listener{
                     case "l":
                         $list = "All of the mines are named as follows:\n";
                         ksort($this->mines, SORT_NATURAL);
-                        foreach ($this->mines as $name => $mine) {
-                            $list .= $name . ", ";
+                        foreach (array_keys($this->mines) as $mine) {
+                            $list .= $mine . ", ";
                         }
+                        rtrim($list, ", \t\n");
                         $sender->sendMessage($list);
                         break;
                     case "reset-all":
@@ -248,8 +249,7 @@ class MineReset extends PluginBase implements Listener{
                 $this->getLogger()->error("The block settings for mine '{$n}' are incorrect");
                 continue;
             }
-            $this->mines[$n] = new Mine(
-                $this,
+            $this->mines[$n] = new Mine($this,
                 $n,
                 new Vector3(min($m[0], $m[1]), min($m[2], $m[3]), min($m[4], $m[5])),
                 new Vector3(max($m[0], $m[1]), max($m[2], $m[3]), max($m[4], $m[5])),

--- a/src/minereset/MineReset.php
+++ b/src/minereset/MineReset.php
@@ -2,40 +2,48 @@
 namespace minereset;
 
 use pocketmine\command\Command;
-use pocketmine\command\CommandExecutor;
 use pocketmine\command\CommandSender;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerInteractEvent;
+use pocketmine\level\Level;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\Config;
 use pocketmine\utils\TextFormat;
 
-class MineReset extends PluginBase implements CommandExecutor, Listener{
-    public $sessions;
-    /** @var  Config */
+class MineReset extends PluginBase implements Listener{
+
+    /** @var string[]|Vector3[] $sessions */
+    public $sessions = [];
+    /** @var Config $mineData */
     public $mineData;
-    /** @var  Mine[] */
-    public $mines;
-    /** @var  RegionBlocker */
+    /** @var Mine[] $mines */
+    public $mines = [];
+    /** @var RegionBlocker $regionBlocker */
     private $regionBlocker;
+
     public function onEnable(){
         @mkdir($this->getDataFolder());
         $this->mineData = new Config($this->getDataFolder() . "mines.yml", Config::YAML, []);
-        $this->mines = [];
         $this->parseMines();
         $this->getServer()->getPluginManager()->registerEvents($this, $this);
         $this->regionBlocker = new RegionBlocker($this);
-        $this->sessions = [];
     }
+
+    /**
+     * @param CommandSender $sender
+     * @param Command $cmd
+     * @param string $label
+     * @param array $args
+     * @return bool
+     */
     public function onCommand(CommandSender $sender, Command $cmd, $label, array $args){
         if(isset($args[0])){
-            if(!$sender->hasPermission("minereset.commmand." . $args[0])){
+            if(!$sender->hasPermission("minereset.commmand." . strtolower($args[0]))){
                 $sender->sendMessage(TextFormat::RED . "You do not have permission." . TextFormat::RESET);
                 return true;
-            }
-            else{
+            }else{
                 switch($args[0]){
                     case "create":
                     case "c":
@@ -52,12 +60,12 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                                 }
                             }
                             else{
-                                $sender->sendMessage(TextFormat::RED . "You must specify a name." . TextFormat::RESET);
+                                $sender->sendMessage("Usage: /mine create <name>");
                                 return true;
                             }
                         }
                         else{
-                            $sender->sendMessage(TextFormat::RED . "Please run command in game." . TextFormat::RESET);
+                            $sender->sendMessage("You must use this command in-game");
                             return true;
                         }
                         break;
@@ -76,7 +84,7 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                             }
                         }
                         else{
-                            $sender->sendMessage(TextFormat::RED . "You must specify a name." . TextFormat::RESET);
+                            $sender->sendMessage("Usage: /mine destroy <mine>");
                             return true;
                         }
                         break;
@@ -89,6 +97,10 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                                     $save = [];
                                     if(count($sets) % 2 === 0) {
                                         foreach ($sets as $key => $item) {
+                                            if(strpos($item, "%")) {
+                                                $sender->sendMessage(TextFormat::RED . "Your format string looks incorrect." . TextFormat::RESET);
+                                                return true;
+                                            }
                                             if ($key & 1) {
                                                 if (isset($save[$sets[$key - 1]])) {
                                                     $save[$sets[$key - 1]] += $item;
@@ -98,12 +110,12 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                                             }
                                         }
                                         $this->mines[$args[1]]->setData($save);
-                                        $sender->sendMessage("Mine setted.");
+                                        $sender->sendMessage("Mine blocks have been saved");
                                         $this->saveConfig();
                                         return true;
                                     }
                                     else{
-                                        $sender->sendMessage(TextFormat::RED . "Your format string looks corrupted." . TextFormat::RESET);
+                                        $sender->sendMessage(TextFormat::RED . "Your format string looks incorrect." . TextFormat::RESET);
                                         return true;
                                     }
                                 }
@@ -113,12 +125,12 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                                 }
                             }
                             else{
-                                $sender->sendMessage(TextFormat::RED . "You must provide at least one value." . TextFormat::RESET);
+                                $sender->sendMessage(TextFormat::RED . "You must provide at least one block with a chance value." . TextFormat::RESET);
                                 return true;
                             }
                         }
                         else{
-                            $sender->sendMessage(TextFormat::RED . "You must specify a name." . TextFormat::RESET);
+                            $sender->sendMessage("Usage: /mine set <mine> <block> <chance>");
                             return true;
                         }
                         break;
@@ -146,6 +158,15 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                             return true;
                         }
                         break;
+                    case "list":
+                    case "l":
+                        $list = "All of the mines are named as follows:\n";
+                        ksort($this->mines, SORT_NATURAL);
+                        foreach ($this->mines as $name => $mine) {
+                            $list .= $name . ", ";
+                        }
+                        $sender->sendMessage($list);
+                        break;
                     case "reset-all":
                         $i = 0;
                         foreach($this->mines as $mine) {
@@ -156,26 +177,35 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                         }
                         $sender->sendMessage("Resetting {$i} mines.");
                         return true;
-                    case "longreset":
-                    case "lr":
-                        $sender->sendMessage(TextFormat::RED . "Long resetting is no longer supported, if you need it use an older version." . TextFormat::RESET);
-                        return true;
                         break;
                 }
             }
         }
         else{
-            $sender->sendMessage(TextFormat::RED . "You must specify the action to perform." . TextFormat::RESET);
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
+
+    /**
+     * @priority LOW
+     * @ignoreCancelled true
+     *
+     * @param PlayerInteractEvent $event
+     */
     public function onBlockTap(PlayerInteractEvent $event){
         if(isset($this->sessions[$event->getPlayer()->getName()])){
             if(isset($this->sessions[$event->getPlayer()->getName()][1])){
+                /** @var Vector3 $a */
                 $a = $this->sessions[$event->getPlayer()->getName()][1];
                 $b = $event->getBlock();
-                $this->mines[$this->sessions[$event->getPlayer()->getName()][0]] = new Mine($this, new Vector3(min($a->getX(), $b->getX()), min($a->getY(), $b->getY()), min($a->getZ(), $b->getZ())), new Vector3(max($a->getX(), $b->getX()), max($a->getY(), $b->getY()), max($a->getZ(), $b->getZ())), $b->getLevel());
+                $this->mines[$this->sessions[$event->getPlayer()->getName()][0]] = new Mine(
+                    $this,
+                    $this->sessions[$event->getPlayer()->getName()][0],
+                    new Vector3(min($a->getX(), $b->getX()), min($a->getY(), $b->getY()), min($a->getZ(), $b->getZ())),
+                    new Vector3(max($a->getX(), $b->getX()), max($a->getY(), $b->getY()), max($a->getZ(), $b->getZ())),
+                    $b->getLevel()->getId()
+                );
                 $event->getPlayer()->sendMessage("Mine created.");
                 unset($this->sessions[$event->getPlayer()->getName()]);
                 $this->saveConfig();
@@ -184,29 +214,62 @@ class MineReset extends PluginBase implements CommandExecutor, Listener{
                 $this->sessions[$event->getPlayer()->getName()][1] = new Vector3($event->getBlock()->getX(), $event->getBlock()->getY(), $event->getBlock()->getZ());
                 $event->getPlayer()->sendMessage("Tap another block to create mine");
             }
+            $event->setCancelled();
         }
     }
+
     public function saveConfig(){
         $this->mineData->setAll([]);
         foreach($this->mines as $n => $mine){
-            $this->mineData->set($n, [$mine->getA()->getX(), $mine->getB()->getX(), $mine->getA()->getY(), $mine->getB()->getY(), $mine->getA()->getZ(), $mine->getB()->getZ(), (count($mine->getData()) > 0 ? $mine->getData() : false) , $mine->getLevel()->getName()]);
+            $this->mineData->set($n, [
+                $mine->getA()->getX(),
+                $mine->getB()->getX(),
+                $mine->getA()->getY(),
+                $mine->getB()->getY(),
+                $mine->getA()->getZ(),
+                $mine->getB()->getZ(),
+                (count($mine->getData()) > 0 ? $mine->getData() : false),
+                $mine->getLevel()->getName()
+            ]);
         }
         $this->mineData->save();
     }
+
     public function parseMines(){
         foreach($this->mineData->getAll() as $n => $m){
-            $this->mines[$n] = new Mine($this, new Vector3(min($m[0], $m[1]), min($m[2], $m[3]), min($m[4], $m[5])), new Vector3(max($m[0], $m[1]), max($m[2], $m[3]), max($m[4], $m[5])), $this->getServer()->getLevelByName($m[7]), $m[6] ?? []);
+            if(!$this->getServer()->getLevelByName($m[7]) instanceof Level) {
+                if(!$this->getServer()->loadLevel($m[7])) {
+                    $this->getLogger()->error("The world '{$m[7]}' of mine '{$n}' is invalid");
+                    continue;
+                }
+                $this->getLogger()->info("Loaded level '{$m[7]}' for mine '{$n}'");
+            }
+            if(!is_array($m[6])) {
+                $this->getLogger()->error("The block settings for mine '{$n}' are incorrect");
+                continue;
+            }
+            $this->mines[$n] = new Mine(
+                $this,
+                $n,
+                new Vector3(min($m[0], $m[1]), min($m[2], $m[3]), min($m[4], $m[5])),
+                new Vector3(max($m[0], $m[1]), max($m[2], $m[3]), max($m[4], $m[5])),
+                $this->getServer()->getLevelByName($m[7])->getId(),
+                $m[6]
+            );
         }
     }
+
+    /**
+     * @param MineResetTask $mineResetTask
+     */
     public function scheduleReset(MineResetTask $mineResetTask){
         $this->getServer()->getScheduler()->scheduleAsyncTask($mineResetTask);
     }
+
     /**
      * @return RegionBlocker
      */
     public function getRegionBlocker(){
         return $this->regionBlocker;
     }
-
-
 }

--- a/src/minereset/MineResetTask.php
+++ b/src/minereset/MineResetTask.php
@@ -8,14 +8,20 @@ use pocketmine\scheduler\AsyncTask;
 use pocketmine\Server;
 
 class MineResetTask extends AsyncTask{
+    /** @var string $chunks */
     private $chunks;
+    /** @var Vector3 $a */
     private $a;
+    /** @var Vector3 $b */
     private $b;
+    /** @var string $ratioData */
     private $ratioData;
+    /** @var int $regionId */
     private $regionId;
+    /** @var int $levelId */
     private $levelId;
+    /** @var Chunk $chunkClass */
     private $chunkClass;
-
     public function __construct(array $chunks, Vector3 $a, Vector3 $b, array $data, $levelId, $regionId, $chunkClass){
         $this->chunks = serialize($chunks);
         $this->a = $a;
@@ -24,6 +30,7 @@ class MineResetTask extends AsyncTask{
         $this->levelId = $levelId;
         $this->regionId = $regionId;
         $this->chunkClass = $chunkClass;
+        parent::__construct(null);
     }
     /**
      * Actions to execute when run
@@ -31,7 +38,6 @@ class MineResetTask extends AsyncTask{
      * @return void
      */
     public function onRun(){
-
         $chunkClass = $this->chunkClass;
         /** @var  Chunk[] $chunks */
         $chunks = unserialize($this->chunks);
@@ -47,11 +53,10 @@ class MineResetTask extends AsyncTask{
             }
             $id[$i] = $blockId;
         }
-
         $m = array_values(unserialize($this->ratioData));
         $sum[0] = $m[0];
-        for ($l = 1; $l < count($m); $l++) $sum[$l] = $sum[$l - 1] + $m[$l];
-
+        for ($l = 1; $l < count($m); $l++)
+            $sum[$l] = $sum[$l - 1] + $m[$l];
         for ($x = $this->a->getX(); $x <= $this->b->getX(); $x++) {
             for ($y = $this->a->getY(); $y <= $this->b->getY(); $y++) {
                 for ($z = $this->a->getZ(); $z <= $this->b->getZ(); $z++) {
@@ -70,12 +75,15 @@ class MineResetTask extends AsyncTask{
         }
         $this->setResult($chunks);
     }
+    /**
+     * @param Server $server
+     */
     public function onCompletion(Server $server){
         $chunks = $this->getResult();
         $plugin = $server->getPluginManager()->getPlugin("MineReset");
         if($plugin instanceof MineReset and $plugin->isEnabled()) {
             $level = $server->getLevel($this->levelId);
-            if ($level != null) {
+            if ($level instanceof Level) {
                 foreach ($chunks as $hash => $chunk) {
                     Level::getXZ($hash, $x, $z);
                     $level->setChunk($x, $z, $chunk);

--- a/src/minereset/RegionBlocker.php
+++ b/src/minereset/RegionBlocker.php
@@ -10,11 +10,18 @@ use pocketmine\utils\TextFormat;
 class RegionBlocker implements Listener{
     /** @var MineReset  */
     private $plugin;
+    /** @var array[] $activeZones */
+    private $activeZones = [];
     public function __construct(MineReset $mineReset){
         $this->plugin = $mineReset;
         $this->activeZones = [];
         $this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
     }
+    /**
+     * @priority HIGH
+     *
+     * @param PlayerMoveEvent $event
+     */
     public function onPlayerMove(PlayerMoveEvent $event){
         if(isset($this->activeZones[$event->getPlayer()->getLevel()->getId()])){
             foreach($this->activeZones[$event->getPlayer()->getLevel()->getId()] as $zone){
@@ -26,6 +33,12 @@ class RegionBlocker implements Listener{
             }
         }
     }
+    /**
+     * @param Vector3 $a
+     * @param Vector3 $b
+     * @param Level $level
+     * @return int
+     */
     public function blockZone(Vector3 $a, Vector3 $b, Level $level){
         if(!isset($this->activeZones[$level->getId()])) $this->activeZones[$level->getId()] = [];
         $id = count($this->activeZones[$level->getId()]);
@@ -33,22 +46,35 @@ class RegionBlocker implements Listener{
         $this->clearZone($level, $id);
         return $id;
     }
-    public function freeZone($id, $level){
-        if($level instanceof Level) $level = $level->getId();
-        if(isset($this->activeZones[$level]) && isset($this->activeZones[$level][$id])){
+    /**
+     * @param int $id
+     * @param int $level
+     */
+    public function freeZone(int $id, int $level){
+        if(isset($this->activeZones[$level]) and isset($this->activeZones[$level][$id])){
             unset($this->activeZones[$level][$id]);
         }
     }
+    /**
+     * @param Vector3 $test
+     * @param Vector3 $a
+     * @param Vector3 $b
+     * @return bool
+     */
     protected function isInsideZone(Vector3 $test, Vector3 $a, Vector3 $b){
-        return ($test->getX() >= $a->getX() && $test->getX() <= $b->getX() && $test->getY() >= $a->getY() && $test->getY() <= $b->getY() && $test->getZ() >= $a->getZ() && $test->getZ() <= $b->getZ());
+        return ($test->getX() >= $a->getX() and $test->getX() <= $b->getX() and $test->getY() >= $a->getY() and $test->getY() <= $b->getY() and $test->getZ() >= $a->getZ() and $test->getZ() <= $b->getZ());
     }
-    protected function clearZone($level, $id){
-        if($level instanceof Level) $level = $level->getId();
-        if(isset($this->activeZones[$level]) && isset($this->activeZones[$level][$id])){
+    /**
+     * @param Level $level
+     * @param int $id
+     */
+    protected function clearZone(Level $level, int $id){
+        $level = $level->getId();
+        if(isset($this->activeZones[$level]) and isset($this->activeZones[$level][$id])){
             foreach($this->plugin->getServer()->getOnlinePlayers() as $player){
-                if($player->getLevel()->getId() === $level && $this->isInsideZone($player->getPosition(), $this->activeZones[$level][$id][0], $this->activeZones[$level][$id][1])){
+                if($player->getLevel()->getId() === $level and $this->isInsideZone($player->getPosition(), $this->activeZones[$level][$id][0], $this->activeZones[$level][$id][1])){
                     $player->teleport($player->getSpawn());
-                    $player->sendMessage("You have been teleported because you were inside a mine when it was resetting.");
+                    $player->sendMessage("You have been teleported because you were inside a mine while it was resetting.");
                 }
             }
         }

--- a/src/minereset/RegionBlocker.php
+++ b/src/minereset/RegionBlocker.php
@@ -51,7 +51,7 @@ class RegionBlocker implements Listener{
      * @param int $level
      */
     public function freeZone(int $id, int $level){
-        if(isset($this->activeZones[$level]) and isset($this->activeZones[$level][$id])){
+        if(isset($this->activeZones[$level]) && isset($this->activeZones[$level][$id])){
             unset($this->activeZones[$level][$id]);
         }
     }
@@ -62,7 +62,7 @@ class RegionBlocker implements Listener{
      * @return bool
      */
     protected function isInsideZone(Vector3 $test, Vector3 $a, Vector3 $b){
-        return ($test->getX() >= $a->getX() and $test->getX() <= $b->getX() and $test->getY() >= $a->getY() and $test->getY() <= $b->getY() and $test->getZ() >= $a->getZ() and $test->getZ() <= $b->getZ());
+        return ($test->getX() >= $a->getX() && $test->getX() <= $b->getX() && $test->getY() >= $a->getY() && $test->getY() <= $b->getY() && $test->getZ() >= $a->getZ() && $test->getZ() <= $b->getZ());
     }
     /**
      * @param Level $level
@@ -70,9 +70,9 @@ class RegionBlocker implements Listener{
      */
     protected function clearZone(Level $level, int $id){
         $level = $level->getId();
-        if(isset($this->activeZones[$level]) and isset($this->activeZones[$level][$id])){
+        if(isset($this->activeZones[$level]) && isset($this->activeZones[$level][$id])){
             foreach($this->plugin->getServer()->getOnlinePlayers() as $player){
-                if($player->getLevel()->getId() === $level and $this->isInsideZone($player->getPosition(), $this->activeZones[$level][$id][0], $this->activeZones[$level][$id][1])){
+                if($player->getLevel()->getId() === $level && $this->isInsideZone($player->getPosition(), $this->activeZones[$level][$id][0], $this->activeZones[$level][$id][1])){
                     $player->teleport($player->getSpawn());
                     $player->sendMessage("You have been teleported because you were inside a mine while it was resetting.");
                 }


### PR DESCRIPTION
### This PR includes the following:
- A new subcommand 'list'
- Debug outputs for invalid config entries to prevent the plugin from being disabled
- Removal of level references to prevent crashes if a level is (replaced by level ids)
- Addition of mine names to the Mine class
- Better usage outputs
- Removal of 'longreset' due to deprecation
- Added better Optimization