### PR TITLE
Be more clever about chunk & subchunk accessing (more performant)

### DIFF
--- a/src/falkirks/minereset/task/ResetTask.php
+++ b/src/falkirks/minereset/task/ResetTask.php
@@ -63,22 +63,26 @@ class ResetTask extends AsyncTask{
 
         $sumCount = count($sum);
 
-        $totalBlocks = ($this->b->x - $this->a->x + 1)*($this->b->y - $this->a->y + 1)*($this->b->z - $this->a->z + 1);
+        //Get these as local variables so they don't keep getting serialized/unserialized every single access
+        $posA = $this->a;
+        $posB = $this->b;
+
+        $totalBlocks = ($posB->x - $posA->x + 1)*($posB->y - $posA->y + 1)*($posB->z - $posA->z + 1);
         $interval = $totalBlocks / 8; //TODO determine the interval programmatically
         $lastUpdate = 0;
         $currentBlocks = 0;
 
-        $currentChunkX = $this->a->x >> 4;
-        $currentChunkZ = $this->a->z >> 4;
+        $currentChunkX = $posA->x >> 4;
+        $currentChunkZ = $posA->z >> 4;
 
-        $currentChunkY = $this->a->y >> 4;
+        $currentChunkY = $posA->y >> 4;
 
         $currentChunk = null;
         $currentSubChunk = null;
 
-        for ($x = $this->a->getX(), $x2 = $this->b->getX(); $x <= $x2; $x++) {
+        for ($x = $posA->getX(), $x2 = $posB->getX(); $x <= $x2; $x++) {
             $chunkX = $x >> 4;
-            for ($z = $this->a->getZ(), $z2 = $this->b->getZ(); $z <= $z2; $z++) {
+            for ($z = $posA->getZ(), $z2 = $posB->getZ(); $z <= $z2; $z++) {
                 $chunkZ = $z >> 4;
                 if($currentChunk === null or $chunkX !== $currentChunkX or $chunkZ !== $currentChunkZ){
                     $currentChunkX = $chunkX;
@@ -91,7 +95,7 @@ class ResetTask extends AsyncTask{
                     }
                 }
 
-                for ($y = $this->a->getY(), $y2 = $this->b->getY(); $y <= $y2; $y++) {
+                for ($y = $posA->getY(), $y2 = $posB->getY(); $y <= $y2; $y++) {
                     $chunkY = $y >> 4;
 
                     if($currentSubChunk === null or $chunkY !== $currentChunkY){


### PR DESCRIPTION
Array-access, recomputing chunk hashes and operating on a Chunk basis really slows things down. This patch optimizes it in the following ways:

- Iterate in XZY order instead of XYZ, this allows caching a chunk reference for faster access and ensures that chunks only need to be visited once.
- Operate directly on subchunks instead of chunks - this reduces the need for constant subchunk array-access and also cuts out a wrapper method. Chunk wrapper methods can be up to 5x more expensive than their SubChunk counterparts.

These changes produce a 30% incremental performance improvement (before 3.2 seconds, after 2.0 seconds, tested on an i7-7700k @ 0.9 GHz in powersave mode) (same area and configuration as #79 ).