### PR TITLE
API BUMP 3.0.0-ALPHA9

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: MineReset
 main: falkirks\minereset\MineReset
 version: 3.0
 author: Falk
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8]
+api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9]
 load: POSTWORLD
 permissions:
  minereset:


### PR DESCRIPTION
Now works with pmmp or spoons that use API 3.0.0-ALPHA9.