### PR TITLE
only listen for right-click on block

### DIFF
--- a/src/falkirks/minereset/listener/CreationListener.php
+++ b/src/falkirks/minereset/listener/CreationListener.php
@@ -32,6 +32,10 @@ class CreationListener implements Listener {
      * @param PlayerInteractEvent $event
      */
     public function onBlockTap(PlayerInteractEvent $event){
+        if($event->getAction() !== PlayerInteractEvent::RIGHT_CLICK_BLOCK){
+            return;
+        }
+
         $session = $this->getPlayerSession($event->getPlayer());
 
         if($session !== null){


### PR DESCRIPTION
client will send both right-click block and right-click air when clicking blocks, which causes bugs when trying to create mines